### PR TITLE
Update README to use markdown math

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,14 @@
 **HighDimPDE.jl** is a Julia package to **solve Highly Dimensional non-local, non-linear PDEs** of the form
 
 
-<!-- $$
+$$
 \begin{aligned}
     (\partial_t u)(t,x) &= \int_{\Omega} f\big(t,x,{\bf x}, u(t,x),u(t,{\bf x}), ( \nabla_x u )(t,x ),( \nabla_x u )(t,{\bf x} ) \big) \, d{\bf x} \\
     & \quad + \big\langle \mu(t,x), ( \nabla_x u )( t,x ) \big\rangle + \tfrac{1}{2} \text{Trace} \big(\sigma(t,x) [ \sigma(t,x) ]^* ( \text{Hess}_x u)(t, x ) \big).
 \end{aligned}
-$$ --> 
+$$
 
-<div align="center"><img style="background: white;" src="https://render.githubusercontent.com/render/math?math=%5Cbegin%7Baligned%7D%0A%20%20%20%20(%5Cpartial_t%20u)(t%2Cx)%20%26%3D%20%5Cint_%7B%5COmega%7D%20f%5Cbig(t%2Cx%2C%7B%5Cbf%20x%7D%2C%20u(t%2Cx)%2Cu(t%2C%7B%5Cbf%20x%7D)%2C%20(%20%5Cnabla_x%20u%20)(t%2Cx%20)%2C(%20%5Cnabla_x%20u%20)(t%2C%7B%5Cbf%20x%7D%20)%20%5Cbig)%20%5C%2C%20d%7B%5Cbf%20x%7D%20%5C%5C%0A%20%20%20%20%26%20%5Cquad%20%2B%20%5Cbig%5Clangle%20%5Cmu(t%2Cx)%2C%20(%20%5Cnabla_x%20u%20)(%20t%2Cx%20)%20%5Cbig%5Crangle%20%2B%20%5Ctfrac%7B1%7D%7B2%7D%20%5Ctext%7BTrace%7D%20%5Cbig(%5Csigma(t%2Cx)%20%5B%20%5Csigma(t%2Cx)%20%5D%5E*%20(%20%5Ctext%7BHess%7D_x%20u)(t%2C%20x%20)%20%5Cbig).%0A%5Cend%7Baligned%7D"></div>
-
-where <!-- $u \colon [0,T] \times \Omega \to \R$ --> <img style="transform: translateY(0.1em); background: white;" src="https://render.githubusercontent.com/render/math?math=u%20%5Ccolon%20%5B0%2CT%5D%20%5Ctimes%20%5COmega%20%5Cto%20%5CR">, <!-- $\Omega\subseteq \R^d$ --> <img style="transform: translateY(0.1em); background: white;" src="https://render.githubusercontent.com/render/math?math=%5COmega%5Csubseteq%20%5CR%5Ed"> is subject to initial and boundary conditions, and where <!-- $d$ --> <img style="transform: translateY(0.1em); background: white;" src="https://render.githubusercontent.com/render/math?math=d"> is large.
+where $u \colon [0,T] \times \Omega \to \mathbb{R}$, $\Omega\subseteq \mathbb{R}^d$ is subject to initial and boundary conditions, and where $d$ is large.
 
 ## Documentation
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://highdimpde.sciml.ai/stable)


### PR DESCRIPTION
Markdown math support was introduced here: https://github.blog/2022-05-19-math-support-in-markdown/
This plays well with GitHub's dark modes:
<img width="830" alt="Screenshot 2022-05-20 at 16 55 03" src="https://user-images.githubusercontent.com/20258504/169555825-b54f3a56-8a51-4547-9e63-52c69dad6d8b.png">

