### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HighDimPDE"
 uuid = "57c578d5-59d4-4db8-a490-a9fc372d19d2"
 authors = ["Victor Boussange <vic.boussange@gmail.com>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -34,7 +34,7 @@ LinearAlgebra = "1.10"
 Random = "1.10"
 Reexport = "1.2.2"
 SafeTestsets = "0.1"
-SciMLBase = "2.42"
+SciMLBase = "2.42, 3"
 SciMLSensitivity = "7.62"
 SparseArrays = "1.10"
 Statistics = "1.10"


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version (minor): 2.2.0 → 2.3.0
- No code changes needed - package doesn't use deprecated SciMLBase v2 patterns
- Supersedes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)