### PR TITLE
[TEST] GPU tests on T4 instead of V100

### DIFF
--- a/.github/workflows/GPU.yml
+++ b/.github/workflows/GPU.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   gpu-tests:
     name: "GPU Tests"
-    runs-on: [self-hosted, gpu-v100]
+    runs-on: [self-hosted, gpu-t4]
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Testing whether HighDimPDE GPU tests pass on arctic1 T4 runners. DO NOT MERGE.