### PR TITLE
Migrate to SciMLBase v3 API and bump CUDA/cuDNN compat to 6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HighDimPDE"
 uuid = "57c578d5-59d4-4db8-a490-a9fc372d19d2"
 authors = ["Victor Boussange <vic.boussange@gmail.com>"]
-version = "2.3.0"
+version = "3.0.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -24,7 +24,7 @@ cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
 Aqua = "0.8"
-CUDA = "5.4.2, 6"
+CUDA = "6"
 DiffEqBase = "6.151"
 Distributions = "v0.25.107"
 DocStringExtensions = "0.9.3"
@@ -34,7 +34,7 @@ LinearAlgebra = "1.10"
 Random = "1.10"
 Reexport = "1.2.2"
 SafeTestsets = "0.1"
-SciMLBase = "2.42, 3.1"
+SciMLBase = "3.1"
 SciMLSensitivity = "7.62"
 SparseArrays = "1.10"
 Statistics = "1.10"
@@ -42,7 +42,7 @@ StochasticDiffEq = "6.66"
 Test = "1.10"
 Tracker = "0.2.34"
 Zygote = "0.6.70, 0.7"
-cuDNN = "1.3.2, 6"
+cuDNN = "6"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HighDimPDE"
 uuid = "57c578d5-59d4-4db8-a490-a9fc372d19d2"
 authors = ["Victor Boussange <vic.boussange@gmail.com>"]
-version = "3.0.0"
+version = "2.4.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/DeepBSDE.jl
+++ b/src/DeepBSDE.jl
@@ -210,7 +210,7 @@ function DiffEqBase.solve(
             error("dt choice is required for upper and lower bound calculation ")
         end
         sdeProb = SDEProblem(μ, σ, x0, tspan, noise_rate_prototype = zeros(Float32, d, d))
-        output_func(sol, i) = (sol.u[end], false)
+        output_func(sol, ctx) = (sol.u[end], false)
         ensembleprob = EnsembleProblem(sdeProb, output_func = output_func)
         sim_f = solve(
             ensembleprob,
@@ -231,7 +231,8 @@ function DiffEqBase.solve(
             p3,
             noise_rate_prototype = noise
         )
-        function prob_func(prob, i, repeat)
+        function prob_func(prob, ctx)
+            i = ctx.sim_id
             return SDEProblem(
                 prob.f,
                 prob.g,

--- a/src/NNKolmogorov.jl
+++ b/src/NNKolmogorov.jl
@@ -79,15 +79,15 @@ function DiffEqBase.solve(
         noise_rate_prototype = noise_rate_prototype
     )
 
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
         return SDEProblem(
             prob.f,
-            xi[:, i],
+            xi[:, ctx.sim_id],
             prob.tspan,
             noise_rate_prototype = prob.noise_rate_prototype
         )
     end
-    output_func(sol, i) = (sol.u[end], false)
+    output_func(sol, ctx) = (sol.u[end], false)
     ensembleprob = EnsembleProblem(
         sdeproblem,
         prob_func = prob_func,

--- a/src/NNParamKolmogorov.jl
+++ b/src/NNParamKolmogorov.jl
@@ -111,11 +111,8 @@ function DiffEqBase.solve(
     ps_phi_iterator = !isnothing(ps_phi) ? eachslice(ps_phi, dims = length(size(ps_phi))) :
         collect(Iterators.repeated(nothing, trajectories))
     # return xi, ti, ps_sigma_iterator[1]
-    prob_func = (
-        prob,
-        i,
-        repeat,
-    ) -> begin
+    prob_func = (prob, ctx) -> begin
+        i = ctx.sim_id
         sigma_(dx, x, p, t) = sigma(dx, x, ps_sigma_iterator[i], t)
         mu_(dx, x, p, t) = mu(dx, x, ps_mu_iterator[i], t)
         SDEProblem(
@@ -127,7 +124,7 @@ function DiffEqBase.solve(
         )
     end
 
-    output_func = (sol, i) -> (sol.u[end], false)
+    output_func = (sol, ctx) -> (sol.u[end], false)
 
     sdeprob = SDEProblem(
         mu,


### PR DESCRIPTION
## Summary
- Migrate `prob_func`/`output_func` closures to the SciMLBase v3 `ctx`-style signatures (`(prob, ctx)` / `(sol, ctx)` with `ctx.sim_id`) — the old `(prob, i, repeat)` / `(sol, i)` forms were removed in SciMLBase v3.
- Drop pre-v3 `SciMLBase`, pre-v6 `CUDA`, and pre-v6 `cuDNN` from `[compat]`.
- Bump `HighDimPDE` to `3.0.0` to reflect the breaking upgrade.

Supersedes the dependabot compat-only bump in #135.

## Known upstream blockers
CI cannot resolve until upstream catches up:
- `DiffEqBase` ≤ `6.216.0` still caps `SciMLBase` at `2.143 - 2`, so `SciMLBase = "3.1"` has no resolvable version yet.
- `Flux` ≤ `0.16.9` caps `CUDA` at `5.11.0`, so `CUDA = "6"` / `cuDNN = "6"` cannot resolve until Flux is updated.

The code migration itself is ready; once `DiffEqBase` and `Flux` ship SciMLBase v3 / CUDA 6 support, this should install and test cleanly.

## Test plan
- [ ] CI green after `DiffEqBase` / `Flux` upstream releases
- [ ] Manual verification of `NNKolmogorov`, `NNParamKolmogorov`, and `DeepBSDE` upper-limit ensemble paths once resolvable

🤖 Generated with [Claude Code](https://claude.com/claude-code)