### PR TITLE
ci(docs): restore Documentation workflow (CPU runner) to fix stable docs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,40 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  build:
+    # Runs on a GitHub-hosted CPU runner (not the self-hosted GPU box).
+    # All executed `@example` blocks use `use_cuda = false`, so no GPU is
+    # required; the previous GPU-runner build segfaulted (exit 139) during
+    # example evaluation, which blocked every v2.x docs deploy.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - name: Install dependencies
+        shell: julia --color=yes --project=docs/ {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
+        run: julia --color=yes --project=docs/ docs/make.jl


### PR DESCRIPTION
## Problem

`https://docs.sciml.ai/HighDimPDE/stable/` is frozen at **v1.2.1 (June 2022)**. The deepbsde tutorial (and all current content) shows up under `/dev/` but never reaches `/stable/`, even though it's present in the v2.3.0 source.

### Root cause

1. **No docs workflow on `main`.** Docs CI was deliberately removed from GitHub Actions in #99 (merged 2024-07-17), and #130 ("Add Documentation CI workflow") was **closed unmerged**. So nothing has deployed docs from `main`.
2. **v2.x tag builds segfault.** The legacy `documentation.yml` that survived on the release tags ran on a self-hosted **GPU** runner and **segfaulted (exit 139)** during `docs/make.jl` `ExpandTemplates`, crashing *before* `deploydocs`. So no v2.x version (v2.0.0–v2.3.0) was ever published to `gh-pages` — `versions.js` still has `DOCUMENTER_NEWEST = "v1.2.1"`, and `stable → v1.2.1`.

Net: `dev` is a stale leftover from an old successful deploy; `stable` cannot advance until a tagged release completes a clean docs build.

## Fix

Restore `.github/workflows/Documentation.yml`, but run on **`ubuntu-latest` (CPU)** instead of the self-hosted GPU box:

- Every *executed* `@example` block uses `use_cuda = false`. The `use_cuda = true` snippets are static ```` ```julia ```` fences (not evaluated), and no executed block does `using CUDA`. So the build needs **no GPU**, and the CPU runner sidesteps the segfault.
- Triggers on push to `main` (deploys `dev`), tag pushes (deploys the version + repoints `stable`), and `pull_request` (build-only validation). Added `workflow_dispatch` so a maintainer can manually deploy against an existing tag.
- Credentials are already in place: the repo has a valid `DOCUMENTER_KEY` secret and matching read-write deploy key.

## Validation

This PR's own `pull_request` run exercises the full `docs/make.jl` build on `ubuntu-latest` (Documenter skips `deploydocs` on PRs, so it's a safe build-only check). Confirm it goes green before merging.

## After merge — to actually repoint `stable`

`stable` only moves on a **tagged-release** build. Two options:
1. **Preferred:** cut a fresh release (master is already at 2.5.0 but untagged past v2.3.0) → TagBot tags it → the tag build deploys and repoints `stable`.
2. **Immediate backfill:** manually run this workflow via `workflow_dispatch` against tag `v2.3.0` to deploy v2.3.0 docs and repoint `stable` without waiting for a new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)