### PR TITLE
Fix QA: drop stale Test dep and resolve re-exported integrator accessors

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,32 @@
 using SciMLTesting
-run_tests()
+using SafeTestsets
+
+# GPU's GROUP semantics are capability-based, not folder-partitioned: the GPU lane
+# runs the *same* Core test files on a CUDA-equipped runner, where the
+# `CUDA.functional()`-gated testsets inside reflect.jl/MCSample.jl self-activate.
+# It therefore cannot be a separate folder of files, so this uses explicit-args
+# run_tests rather than folder discovery.
+function core_body()
+    @safetestset "ProblemConstructors" include("ProblemConstructor.jl")
+    @safetestset "reflect" include("reflect.jl")
+    @safetestset "MLP" include("MLP.jl")
+    @safetestset "Deep Splitting" include("DeepSplitting.jl")
+    @safetestset "DeepBSDE" include("DeepBSDE.jl")
+    @safetestset "MC Sample" include("MCSample.jl")
+    @safetestset "NNStopping" include("NNStopping.jl")
+    @safetestset "NNKolmogorov" include("NNKolmogorov.jl")
+    return @safetestset "NNParamKolmogorov" include("NNParamKolmogorov.jl")
+end
+
+run_tests(;
+    core = core_body,
+    groups = Dict(
+        # GPU is the self-hosted CUDA runner lane: the same Core suite, where the
+        # CUDA-gated testsets run because CUDA.functional() is true there.
+        "GPU" => core_body,
+    ),
+    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
+    # Curated "All": run only Core. GPU (self-hosted CUDA lane) and QA stay
+    # selectable by name but out of the aggregate.
+    all = ["Core"],
+)


### PR DESCRIPTION
## What (rebased onto current `main`, 2026-07-05)

Rebased onto `main` (now at #156 "QA: run_qa v1.6 + ExplicitImports"). The QA parts of the original PR are **already on `main` via #156** and were absorbed by the rebase:

- **Stale `Test` dep** — #156 already moved `Test` from `[deps]` to `[extras]`/`[targets].test`. Nothing left to do; the rebased branch's `Project.toml` equals `main`.
- **`du_cache`/`u_cache`/`user_cache` undefined-exports** — #156 handled this via `aqua_broken = (:undefined_exports,)` (tracking #157). The rebased branch's `src/HighDimPDE.jl` equals `main` (the original `using DiffEqBase: du_cache, ...` approach was dropped to avoid an Unexpected-Pass conflict with #156's `aqua_broken`).

**The only surviving change is the GPU CI harness fix** (`test/runtests.jl`, +31/-1), which is still needed: `GPU Tests` is red on `main` with
```
ArgumentError: run_tests (folder mode): GROUP="GPU" is not "All"/"Core"/"QA" and is not a group declared in test_groups.toml (declared: ["Core", "QA"]).
```
GPU is a capability lane (same Core files on a CUDA runner, where `CUDA.functional()`-gated testsets self-activate), not a folder. Switched to explicit-args `run_tests` (`core` = the 9 Core files; `groups = {"GPU" => core_body}`; `qa = test/qa`; `all = ["Core"]`). This is the documented SciMLTesting explicit-args API.

**Verified locally** (Julia 1.12.6, released SciMLTesting 1.6): routing is correct — `GROUP=GPU` → Core body (no ArgumentError), `GROUP=Core` → Core, `GROUP=All` → Core, `GROUP=QA` → QA. `test/runtests.jl` parses cleanly and is Runic-clean.

## Out of scope / pre-existing (NOT introduced here)

**Core (julia 1 = 1.12, julia pre = 1.13), all OSes: Julia 1.12+ LLVM codegen segfault.** `signal 11` at `test/DeepBSDE.jl:19`, in `emit_unbox`/`emit_unboxed_coercion` (`codegen.cpp`) while JIT-compiling the Zygote adjoint of the DeepBSDE ensemble SDE solve. **Reproduces byte-identically on unmodified `main`** (master run 28647091704, job 84956919471 — same `signal 11`, same `DeepBSDE.jl:19`). Core **lts (1.10)** is green with identical resolved deps, so this is purely a Julia-version codegen crash, not a HighDimPDE logic bug and not fixable in-package. Untouched by this PR.

Please ignore until reviewed by @ChrisRackauckas.
