### PR TITLE
Bump version to 2.5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HighDimPDE"
 uuid = "57c578d5-59d4-4db8-a490-a9fc372d19d2"
 authors = ["Victor Boussange <vic.boussange@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
Automated patch version bump (2.5.0 -> 2.5.1) to release unreleased commits on `main` via JuliaRegistrator.