### PR TITLE
Release prep: bump version to 2.5.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HighDimPDE"
 uuid = "57c578d5-59d4-4db8-a490-a9fc372d19d2"
 authors = ["Victor Boussange <vic.boussange@gmail.com>"]
-version = "2.5.1"
+version = "2.5.2"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
## Summary

Bumps `HighDimPDE` from `2.5.1` to `2.5.2`. The last registered release (v2.5.1) corresponds to commit `9cd0e71` ("Bump version to 2.5.1 (#158)"), but the tree content has since changed without a version bump (registry tree-sha for 2.5.1 no longer matches HEAD's root tree).

## Changes since v2.5.1 (commit 9cd0e71)

- `3d35e5b` QA: run_qa v1.6 form + ExplicitImports
- `74cea11` build(deps): bump actions/checkout from 6 to 7
- `fe18924` Use SciMLTesting 2.1 QA docs check (#159)

Concretely, the diff (`git diff 9cd0e71 HEAD`) touches:
- `src/HighDimPDE.jl`, `src/MCSample.jl`: added docstrings for the existing `PIDESolution` struct and `NoSampling` struct (no behavior/API change).
- `test/qa/qa.jl`, `test/qa/Project.toml`, `Project.toml`: bumped the test-only `SciMLTesting` compat lower bound from `1.6` to `2.1` and adopted `SciMLTesting`'s `api_docs_kwargs` QA option (test/CI tooling only, not a runtime dependency).
- `test/GPU/gpu.jl`, `test/test_groups.toml`: added a new GPU test group for CI (test infrastructure only).

No new exported API, no functional/runtime source changes, no breaking changes — everything is docs, tests, and CI.

## Bump type: PATCH (2.5.1 -> 2.5.2)

Docs-only additions (docstrings) and test/CI-only changes qualify as a patch release per SemVer.

## Compat bounds

`SciMLTesting`'s compat lower bound was already raised from `1.6` to `2.1` in the diff itself (commit `fe18924`), consistent with its new `api_docs_kwargs` usage in `test/qa/qa.jl`. `SciMLTesting` is a test-only dependency (`[extras]`/`[targets]`), not a runtime dependency, so this does not affect downstream consumers. No other SciML-ecosystem compat bounds were touched, and none needed adjustment — no new APIs from `SciMLBase`, `DiffEqBase`, `SciMLSensitivity`, `StochasticDiffEq`, etc. are used in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)