### PR TITLE
test: use Float32 noise in GPU reflect equivalence test

### DIFF
--- a/test/reflect.jl
+++ b/test/reflect.jl
@@ -41,7 +41,7 @@ if CUDA.functional()
         @testset "testing equivalence cpu gpu" begin
             batch_size = 1000
             a = repeat(X0[:], 1, batch_size)
-            b = a + 2 .* randn(size(a))
+            b = a + 2f0 .* randn(Float32, size(a))
             a = hcat(X0, a) |> gpu
             b = hcat(X1, b) |> gpu
             s = -1.0f0


### PR DESCRIPTION
Fixes GPU reflect test type mismatch: randn on CPU Array produces Float64 while GPU path uses Float32.

## Test plan
- [x] Local change is one-line type alignment in `test/reflect.jl`

Made with [Cursor](https://cursor.com)