### PR TITLE
Apply current Runic formatting

### DIFF
--- a/src/MLP.jl
+++ b/src/MLP.jl
@@ -235,11 +235,11 @@ function _ml_picard_mlt(
     NUM_THREADS = Threads.nthreads()
     tasks = [
         Threads.@spawn(
-                _ml_picard_call(
-                    M, L, K, x, s, t, mc_sample!, g, f, verbose,
-                    NUM_THREADS, thread_id, prob, neumann_bc
-                )
-            ) for thread_id in 1:NUM_THREADS
+            _ml_picard_call(
+                M, L, K, x, s, t, mc_sample!, g, f, verbose,
+                NUM_THREADS, thread_id, prob, neumann_bc
+            )
+        ) for thread_id in 1:NUM_THREADS
     ]
 
     # first level

--- a/test/reflect.jl
+++ b/test/reflect.jl
@@ -41,7 +41,7 @@ if CUDA.functional()
         @testset "testing equivalence cpu gpu" begin
             batch_size = 1000
             a = repeat(X0[:], 1, batch_size)
-            b = a + 2f0 .* randn(Float32, size(a))
+            b = a + 2.0f0 .* randn(Float32, size(a))
             a = hcat(X0, a) |> gpu
             b = hcat(X1, b) |> gpu
             s = -1.0f0

--- a/test/shared/DeepBSDE_Han.jl
+++ b/test/shared/DeepBSDE_Han.jl
@@ -42,10 +42,10 @@ end
     # sub-neural network approximating the spatial gradients at time point
     σᵀ∇u = [
         Flux.Chain(
-                Dense(d, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, d)
-            ) for i in 1:time_steps
+            Dense(d, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, d)
+        ) for i in 1:time_steps
     ]
 
     alg = DeepBSDE(u0, σᵀ∇u, opt = opt)
@@ -94,10 +94,10 @@ end
     # sub-neural network approximating the spatial gradients at time point
     σᵀ∇u = [
         Flux.Chain(
-                Dense(d, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, d)
-            ) for i in 1:time_steps
+            Dense(d, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, d)
+        ) for i in 1:time_steps
     ]
 
     alg = DeepBSDE(u0, σᵀ∇u, opt = opt)
@@ -145,11 +145,11 @@ end
     )
     σᵀ∇u = [
         Flux.Chain(
-                Dense(d, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, d)
-            ) for i in 1:time_steps
+            Dense(d, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, d)
+        ) for i in 1:time_steps
     ]
 
     alg = DeepBSDE(u0, σᵀ∇u, opt = opt)
@@ -198,10 +198,10 @@ end
     # sub-neural network approximating the spatial gradients at time point
     σᵀ∇u = [
         Flux.Chain(
-                Dense(d, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, d)
-            ) for i in 1:time_steps
+            Dense(d, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, d)
+        ) for i in 1:time_steps
     ]
 
     alg = DeepBSDE(u0, σᵀ∇u, opt = opt)
@@ -252,11 +252,11 @@ end
     # sub-neural network approximating the spatial gradients at time point
     σᵀ∇u = [
         Flux.Chain(
-                Dense(d, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, d)
-            ) for i in 1:time_steps
+            Dense(d, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, d)
+        ) for i in 1:time_steps
     ]
 
     alg = DeepBSDE(u0, σᵀ∇u, opt = opt)
@@ -339,11 +339,11 @@ end
 
     σᵀ∇u = [
         Flux.Chain(
-                Dense(d, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, hls, relu),
-                Dense(hls, d)
-            ) for i in 1:time_steps
+            Dense(d, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, hls, relu),
+            Dense(hls, d)
+        ) for i in 1:time_steps
     ]
     alg = DeepBSDE(u0, σᵀ∇u, opt = opt)
 


### PR DESCRIPTION
## What changed and why

Apply Runic 1.10's canonical formatting to the three files that currently fail the repository-wide format check. This is a mechanical-only change: it normalizes comprehension indentation and the `Float32` literal spelling, with no behavior or documentation changes.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Root cause

The hosted Runic failure reproduces locally on a clean current-main checkout. With the CI version, Runic 1.9.0, `git bisect` passes at `a7b882b466d17c20bcb31cf5367a317bb63430e6` and identifies `44fbfc9192d77aad76ee92103a02bd5704647a62` (https://github.com/SciML/HighDimPDE.jl/pull/169) as the first failing commit; that commit introduced the non-canonical `2f0` spelling. Current Runic 1.10 additionally canonicalizes two older comprehension layouts, so this PR formats all three files reported by the repository's unpinned major-1 formatter check.

## Failing before

On clean current main with Runic 1.9.0:

```console
$ julia +release --project=../.tmp/runic19-env -m Runic --check --diff .
diff --git a/test/reflect.jl b/test/reflect.jl
@@
-            b = a + 2f0 .* randn(Float32, size(a))
+            b = a + 2.0f0 .* randn(Float32, size(a))
# exit 1
```

With current Runic 1.10.0, the same clean-main check also reports layout changes in `src/MLP.jl` and `test/shared/DeepBSDE_Han.jl`.

## Passing after

```console
$ julia +release --project=../.tmp/runic-env -m Runic --check --diff .
# exit 0; no output

$ GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   20     20  2m44.9s
     Testing HighDimPDE tests passed

$ GROUP=Core julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary:       | Pass  Total
ProblemConstructors |  154    154
reflect             |    2      2
MLP                 |   23     23
Deep Splitting      |   19     19
DeepBSDE            |    6      6
MC Sample           |    7      7
NNStopping          |    2      2
NNParamKolmogorov   |    1      1
     Testing HighDimPDE tests passed

$ typos src/MLP.jl test/reflect.jl test/shared/DeepBSDE_Han.jl
# exit 0; no output

$ git diff --check HEAD^
# exit 0; no output
```

`NNKolmogorov` also ran in the Core group, and the complete group exited successfully; its summary was not retained in the captured terminal tail.

## Not verified here

- The GPU path was not run because a functional CUDA device is unavailable. The changed GPU-gated line is formatting-only.
- Docs were not rebuilt on this formatter-only branch because current main has a separately bisected docs self-compatibility failure. Draft PR https://github.com/SciML/HighDimPDE.jl/pull/170 fixes that one-line docs compatibility issue and passes the strict docs build.
- Julia pre-release and downstream jobs were not run locally.

## Links

- Companion docs fix: https://github.com/SciML/HighDimPDE.jl/pull/170
- First Runic-failing commit: https://github.com/SciML/HighDimPDE.jl/commit/44fbfc9192d77aad76ee92103a02bd5704647a62
- Introducing PR: https://github.com/SciML/HighDimPDE.jl/pull/169
- Hosted failure: https://github.com/SciML/HighDimPDE.jl/actions/runs/33048174211

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
