### PR TITLE
Release HighDimPDE 2.7.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HighDimPDE"
 uuid = "57c578d5-59d4-4db8-a490-a9fc372d19d2"
 authors = ["Victor Boussange <vic.boussange@gmail.com>"]
-version = "2.7.0"
+version = "2.7.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
Bumps `HighDimPDE` 2.7.0 -> 2.7.1 (patch).

Source files changed since 2.7.0:
- `src/MLP.jl`

Commits:
- compat: drop the unregistered SafeTestsets 1.x major (#168)
- test: use Float32 noise in GPU reflect equivalence test (#169)
- Fix docs compatibility with HighDimPDE 2 (#170)
- Apply current Runic formatting (#171)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
