### PR TITLE
Remove x86 CI lane (BFloat16s i686)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,9 +2,6 @@
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
-["1"]
-os = ["ubuntu-latest"]
-
 [QA]
 versions = ["lts", "1"]
 

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,11 +2,8 @@
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
-["Core 32-bit"]
-group = "Core"
-versions = ["1"]
+["1"]
 os = ["ubuntu-latest"]
-arch = "x86"
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- Drop 32-bit Core CI lane until [JuliaMath/BFloat16s#127](https://github.com/JuliaMath/BFloat16s.jl/pull/127) lands (Flux → NNlib → BFloat16s LLVM soft-promote failure on i686).

## Test plan
- [ ] Non-x86 CI green; no x86 job in matrix


Made with [Cursor](https://cursor.com)